### PR TITLE
Temperature reading bugfixes

### DIFF
--- a/DRIVERS/MDIS_LL/SMB2/TOOLS/SMB2_SHC_CTRL/COM/smb2_shc_ctrl.c
+++ b/DRIVERS/MDIS_LL/SMB2/TOOLS/SMB2_SHC_CTRL/COM/smb2_shc_ctrl.c
@@ -104,7 +104,7 @@ static void usage(void)
 		"    devName      device name e.g. smb2_1                   \n"
 		"    -?           Usage                                     \n"
 		"    -t           Get system/ambient temperature                    \n"
-		"    -T=[dec]     Set ambient temperature (Celsius) for FAN control \n"		
+		"    -T=[dec]     Set ambient temperature (Celsius) for FAN control \n"
 		"    -i           Get shelf controller API identifier       \n"
 		"    -p=[psu_id]  Get status of one or all PSU              \n"
 		"                 (psu_id: 0 to 3, 0: to get all psu status)\n"
@@ -349,7 +349,8 @@ static void print_ups(int32 ups_id)
 static void get_temperature()
 {
 	int err;
-	int16 tempK, tempC;
+        u_int16 tempK = 0;
+        int16 tempC = 0;
 
 	err = SMB2SHC_GetTemperature((u_int16*)&tempK);
 	if (err) {
@@ -381,7 +382,7 @@ static void set_temperature(int32 tempC)
 	if (err) {
 		PrintError("***ERROR: SMB2SHC_SET_TEMP", err);
 	}
-	else{	
+	else{
 		/* read back temperature */
 		err = SMB2SHC_GetTemperature((u_int16*)&tempK);
 		if (err) {

--- a/LIBSRC/SMB2_SHC/COM/smb2_shc.c
+++ b/LIBSRC/SMB2_SHC/COM/smb2_shc.c
@@ -232,7 +232,7 @@ int32 __MAPILIB SMB2SHC_GetTemperature(u_int16 *tempK)
 									SHC_TEMP_OPCODE, tempK);
 	}
 	else{
-		*tempK = *tempK | ((u_int16)blkData[2]<<8); /* MSB */
+		*tempK = ((u_int16)blkData[2]<<8); /* MSB */
 		*tempK = *tempK |  (u_int16)blkData[1];     /* LSB */
 }
 


### PR DESCRIPTION
* Prevent reading of uninitialized variable which caused erratic temperature reading during temperature override
* Fix temperature measurement in celsius saved in unsigned variable, resulting in overfrlow when temperature below 273 degree Kelvin.